### PR TITLE
fix: change error message to Enter the content to comment!

### DIFF
--- a/src/intl.ts
+++ b/src/intl.ts
@@ -123,8 +123,8 @@ export const commonMessages = defineMessages({
     defaultMessage: "Comment Task Success",
   },
   commentError: {
-    id: "aXCniL",
-    defaultMessage: "Please receive information to comment !",
+    id: "/TlD8b",
+    defaultMessage: "Please enter the content to comment!",
   },
   savedfaild: {
     id: "0Bgf0g",


### PR DESCRIPTION
* change unsuitable error message "Please receive information to comment !" to "Please enter the content to comment!"