### PR TITLE
Bugfix/issue 78/userlogo name overlap and dateformat not user friendly

### DIFF
--- a/src/taskboard/components/TaskComment/TaskComment.tsx
+++ b/src/taskboard/components/TaskComment/TaskComment.tsx
@@ -162,7 +162,10 @@ const Comment = ({ comments }) => {
             </Typography>
           )}
 
-          <Typography style={{ fontSize: "12px" }} variant="subtitle2">
+          <Typography
+            style={{ fontSize: "10px", fontStyle: "italic" }}
+            variant="subtitle2"
+          >
             Commented on{" "}
             <b>{`${new Intl.DateTimeFormat("en-US", {
               month: "long",
@@ -171,7 +174,12 @@ const Comment = ({ comments }) => {
               hour: "numeric",
               minute: "numeric",
               hour12: true,
-            }).format(new Date(comments.updatedAt))}`}</b>
+            }).format(
+              new Date(
+                new Date(comments.updatedAt).getTime() -
+                  new Date().getTimezoneOffset() * 60000,
+              ),
+            )}`}</b>
           </Typography>
         </div>
         <div className={classes.commentContent}>

--- a/src/taskboard/components/TaskComment/TaskComment.tsx
+++ b/src/taskboard/components/TaskComment/TaskComment.tsx
@@ -21,8 +21,12 @@ const useStyles = makeStyles(
     container: {
       display: "flex",
       alignItems: "start",
+      gap: "15px",
       marginTop: theme.spacing(2),
       marginBottom: theme.spacing(3),
+      "& .MuiButtonBase-root": {
+        paddingRight: 0,
+      },
     },
     avatar: {
       width: "40px",
@@ -31,7 +35,11 @@ const useStyles = makeStyles(
     },
     commentInfo: {
       display: "flex",
-      alignItems: "center",
+      alignItems: "baseline",
+      flexWrap: "wrap",
+    },
+    commentContent: {
+      marginTop: "10px",
     },
     username: {
       fontWeight: "bold",
@@ -139,10 +147,10 @@ const Comment = ({ comments }) => {
   const classes = useStyles();
   return (
     <div className={classes.container}>
-      <div style={{ width: "8%", cursor: "pointer" }}>
+      <div style={{ cursor: "pointer", paddingRight: 0 }}>
         <UserChip user={comments.User} displayName={false} />
       </div>
-      <div style={{ width: "92%" }}>
+      <div>
         <div className={classes.commentInfo}>
           {comments.User.lastname && comments.User.firstname ? (
             <Typography variant="subtitle1" className={classes.username}>
@@ -154,9 +162,19 @@ const Comment = ({ comments }) => {
             </Typography>
           )}
 
-          <Typography variant="subtitle2">{`${comments.updatedAt}`}</Typography>
+          <Typography style={{ fontSize: "12px" }} variant="subtitle2">
+            Commented on{" "}
+            <b>{`${new Intl.DateTimeFormat("en-US", {
+              month: "long",
+              day: "numeric",
+              year: "numeric",
+              hour: "numeric",
+              minute: "numeric",
+              hour12: true,
+            }).format(new Date(comments.updatedAt))}`}</b>
+          </Typography>
         </div>
-        <div>
+        <div className={classes.commentContent}>
           <Typography variant="body2">{comments.content}</Typography>
         </div>
       </div>


### PR DESCRIPTION
* make user logo and name not overlap and format comment timestamp 
to be more user-friendly
* format server time to local time

Before:
![image](https://user-images.githubusercontent.com/130524907/231731568-171337f8-2c9b-4e94-8576-4e9ae6546e8a.png)
After:
![image](https://user-images.githubusercontent.com/130524907/231731454-2401eca1-ebd4-4276-bb9e-2eb801189500.png)
