### PR TITLE
fix: modify error messages from ajv validation to be more user-friendly

### DIFF
--- a/src/hooks/useFormSchema.ts
+++ b/src/hooks/useFormSchema.ts
@@ -4,6 +4,18 @@ import { useEffect, useMemo } from "react";
 
 import { CustomSchemaBridge } from "./customSchemaBridge";
 
+const errorMessages = {
+  currentOffice: "You must select your current office",
+  destinationOffice: "You must select your destination office",
+  dueDate: "You must select a due date!",
+  dueDateStart: "You must select a start date",
+  dueDateEnd: "You must select an end date",
+  content: "You must enter some content",
+  type: "You must select the device type",
+  detail: "You must enter some details about the device",
+  quantity: "You must specify how many devices you want",
+};
+
 const ajv = new Ajv({
   allErrors: true,
   formats: { date: true },
@@ -15,7 +27,16 @@ function createValidator(schema: object) {
 
   return (model: object) => {
     validator(model);
-    return validator.errors?.length ? { details: validator.errors } : null;
+    return validator.errors?.length
+      ? {
+          details: validator.errors.map(error => {
+            const customMessage =
+              errorMessages[error.message.match(/'([^']+)'/)[1]];
+            const message = customMessage || error.message;
+            return { ...error, message };
+          }),
+        }
+      : null;
   };
 }
 


### PR DESCRIPTION
* modify the error messages of each form from ajv validation to be more user-friendly (this commit is about modifying the messages, I haven't fixed the validation for each required field"

Before: 

![image](https://user-images.githubusercontent.com/130524907/232009363-02cf09cf-f013-4a22-8936-9ffdaf6591a0.png)
![image](https://user-images.githubusercontent.com/130524907/232010059-f8859ee3-0f7b-41e3-867b-8adeda1550c5.png)

After:

![image](https://user-images.githubusercontent.com/130524907/232009553-d69da1ff-30ab-40e8-ac40-9179b70b542a.png)
![image](https://user-images.githubusercontent.com/130524907/232009967-f5080c97-af2a-43b0-aa0a-6d45f3313545.png)
