### PR TITLE
fix: change the create request workflow

### DIFF
--- a/src/taskboard/components/FormCreateTask/FormCreateTask.tsx
+++ b/src/taskboard/components/FormCreateTask/FormCreateTask.tsx
@@ -8,11 +8,11 @@ import {
   useGetTaskDefinitionQuery,
 } from "@saleor/graphql";
 import useChoiceSearch from "@saleor/hooks/useChoiceSearch";
-import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
+import { useTaskBoard } from "@saleor/hooks/useTaskBoard";
 import { commonMessages } from "@saleor/intl";
 import { iconClose, iconModal, useCloseIconStyles } from "@saleor/styles/modal";
-import { taskUrl } from "@saleor/taskboard/urls";
+import { getTaskByBoard } from "@saleor/taskboard/queries";
 import { createNumberId } from "@saleor/utils/createNumberId";
 import { mapEdgesToItems } from "@saleor/utils/maps";
 import React, { useMemo, useState } from "react";
@@ -28,20 +28,25 @@ interface Props {
 }
 
 const FormCreateTask: React.FC<Props> = ({ onClose, id }) => {
-  const navigate = useNavigator();
+  const taskBoardData = useTaskBoard(id);
   const notify = useNotifier();
 
   const closeIconClasses = useCloseIconStyles();
 
   const [createTaskMutation, { loading }] = useCreateTaskMutation({
-    onCompleted: data => {
+    onCompleted: () => {
       notify({
         status: "success",
         text: intl.formatMessage(commonMessages.savedChanges),
       });
       onClose();
-      navigate(taskUrl(`${data.createTaskInput.id}`));
     },
+    refetchQueries: [
+      {
+        query: getTaskByBoard,
+        variables: { definitionId: taskBoardData.taskDefinitionId },
+      },
+    ],
   });
   const TaskDefinitionQuery = useGetTaskDefinitionQuery();
   const data = useMemo(() => {

--- a/src/taskboard/components/TaskBoard/TaskBoard.tsx
+++ b/src/taskboard/components/TaskBoard/TaskBoard.tsx
@@ -57,7 +57,10 @@ export const TaskBoard: React.FC<TaskBoardProps> = ({
   viewByStatus,
 }) => {
   const navigate = useNavigator();
-  const [fetch, { data }] = useGetTaskByBoardLazyQuery();
+  const [fetch, { data }] = useGetTaskByBoardLazyQuery({
+    fetchPolicy: "cache-and-network",
+    pollInterval: 5000,
+  });
   useEffect(() => {
     if (taskBoardData.taskDefinitionId) {
       fetch({

--- a/src/taskboard/components/TaskDetailPage/TaskDetailPage.tsx
+++ b/src/taskboard/components/TaskDetailPage/TaskDetailPage.tsx
@@ -136,52 +136,54 @@ const TaskDetailPage: React.FC<ITaskDetailProps> = ({
               loading={loading}
             ></SubTask>
           )}
-          <List className={classes.subTaskList}>
-            <h2 className={classes.subTaskTitle}>Sub Tasks</h2>
-            {taskDetail?.Tasks?.map(subtask => {
-              return (
-                <>
-                  <ListItem
-                    key={subtask.id}
-                    className={classes.subTaskContainer}
-                  >
-                    <div
-                      className={classes.subTask}
-                      onClick={() => handleOpenModalSubTask(subtask.id)}
+          {taskDetail?.Tasks?.length !== 0 && (
+            <List className={classes.subTaskList}>
+              <h2 className={classes.subTaskTitle}>Sub Tasks</h2>
+              {taskDetail?.Tasks?.map(subtask => {
+                return (
+                  <>
+                    <ListItem
+                      key={subtask.id}
+                      className={classes.subTaskContainer}
                     >
-                      <ListItemText
-                        primary={subtask.title}
-                        style={{ maxWidth: "250px" }}
-                      />
-                      <ListItemText
-                        primary={
-                          subtask.state && (
-                            <Pill label={subtask.state} color="warning" />
-                          )
-                        }
-                        style={{ maxWidth: "160px" }}
-                      />
-                      <ListItemText
-                        primary={
-                          subtask.status && (
-                            <Pill label={subtask.status} color="success" />
-                          )
-                        }
-                        style={{ maxWidth: "130px" }}
-                      />
-                      <ListItemText
-                        primary={subtask.priority}
-                        style={{ maxWidth: "50px" }}
-                      />
-                    </div>
-                    <ListItemAvatar style={{ width: "5%" }}>
-                      <UserChip user={subtask.User} displayName={false} />
-                    </ListItemAvatar>
-                  </ListItem>
-                </>
-              );
-            })}
-          </List>
+                      <div
+                        className={classes.subTask}
+                        onClick={() => handleOpenModalSubTask(subtask.id)}
+                      >
+                        <ListItemText
+                          primary={subtask.title}
+                          style={{ maxWidth: "250px" }}
+                        />
+                        <ListItemText
+                          primary={
+                            subtask.state && (
+                              <Pill label={subtask.state} color="warning" />
+                            )
+                          }
+                          style={{ maxWidth: "160px" }}
+                        />
+                        <ListItemText
+                          primary={
+                            subtask.status && (
+                              <Pill label={subtask.status} color="success" />
+                            )
+                          }
+                          style={{ maxWidth: "130px" }}
+                        />
+                        <ListItemText
+                          primary={subtask.priority}
+                          style={{ maxWidth: "50px" }}
+                        />
+                      </div>
+                      <ListItemAvatar style={{ width: "5%" }}>
+                        <UserChip user={subtask.User} displayName={false} />
+                      </ListItemAvatar>
+                    </ListItem>
+                  </>
+                );
+              })}
+            </List>
+          )}
           <ModalSubTask
             modalOpen={modalOpen}
             onModalOpen={setModalOpen}


### PR DESCRIPTION
I fix the create request flow as follows:

- When creating a new request, instead of navigating to the request detail page, w2 will remain in the request lists page. For example, if we create a new WFH request, instead of navigating to the newly created WFH request, w2 will remain in the WFH request lists page. (I removed the navigation part and add refetchQueries property to refetch the query)
- After creating the new request successfully, a notification shows up on the top right of the screen, and a new request shows up in the REQUEST section.
![image](https://user-images.githubusercontent.com/130524907/234487405-a6531387-cc10-47cf-b96f-5f6acb19c7d2.png)
- When the request changes from REQUEST state to PM_APPROVAL state, it will move to the PM APPROVAL section.
- The request lists page fetches data every 5 seconds to reflect the state change. (I added the pollInterval to fetch every 5 seconds and added the fetchPolicies to "cache-and-network" so that when we switch between pages, the app will check the cached data and update new data if there is any)
![image](https://user-images.githubusercontent.com/130524907/234487673-5f3f1d2e-cfe3-442d-986d-83025a03ae69.png)


 
