### PR TITLE
fix: validate and show errors if submitting the same current and destination office

### DIFF
--- a/src/components/FormSchema/FormSchema.tsx
+++ b/src/components/FormSchema/FormSchema.tsx
@@ -103,10 +103,10 @@ export function FormSchema(props: PropsFormSchema) {
             name="dueDate"
             errorMessage="You must select a due date"
           />
-          <AutoField name="content" />
+          <AutoField name="reason" />
           <ErrorField
-            name="content"
-            errorMessage="You must enter some content"
+            name="reason"
+            errorMessage="You must specify a reason for your request"
           />
           <SubmitField />
         </>
@@ -117,24 +117,18 @@ export function FormSchema(props: PropsFormSchema) {
       content = (
         <>
           <AutoField name="currentOffice" />
-          <ErrorField
-            name="currentOffice"
-            errorMessage="You must select your current office"
-          />
+          <ErrorField name="currentOffice" />
           <AutoField name="destinationOffice" />
-          <ErrorField
-            name="destinationOffice"
-            errorMessage="You must select your destination office"
-          />
+          <ErrorField name="destinationOffice" />
           <AutoField name="dueDate" />
           <ErrorField
             name="dueDate"
             errorMessage="You must select a due date"
           />
-          <AutoField name="content" />
+          <AutoField name="reason" />
           <ErrorField
-            name="content"
-            errorMessage="You must enter some content"
+            name="reason"
+            errorMessage="You must specify a reason for your request"
           />
           <SubmitField />
         </>
@@ -154,10 +148,10 @@ export function FormSchema(props: PropsFormSchema) {
             name="dueDateEnd"
             errorMessage="You must select an end date of your WFH request"
           />
-          <AutoField name="content" />
+          <AutoField name="reason" />
           <ErrorField
-            name="content"
-            errorMessage="You must enter some content"
+            name="reason"
+            errorMessage="You must specify a reason for your request"
           />
           <SubmitField />
         </>

--- a/src/hooks/useFormSchema.ts
+++ b/src/hooks/useFormSchema.ts
@@ -15,6 +15,32 @@ function createValidator(schema: object) {
 
   return (model: object) => {
     validator(model);
+    if (
+      typeof (model as any).currentOffice !== "undefined" &&
+      typeof (model as any).destinationOffice !== "undefined"
+    ) {
+      if ((model as any).currentOffice === (model as any).destinationOffice) {
+        validator.errors = [];
+        validator.errors.push({
+          instancePath: "",
+          schemaPath: "#/required",
+          keyword: "required",
+          params: {
+            missingProperty: "currentOffice",
+          },
+          message: "Current office and destination office cannot be the same",
+        });
+        validator.errors.push({
+          instancePath: "",
+          schemaPath: "#/required",
+          keyword: "required",
+          params: {
+            missingProperty: "destinationOffice",
+          },
+          message: "Current office and destination office cannot be the same",
+        });
+      }
+    }
     return validator.errors?.length
       ? {
           details: validator.errors.map(error => {
@@ -37,6 +63,18 @@ function createValidator(schema: object) {
                 ...error,
                 message:
                   "Maximum number of requested device must be less than or equal to 100",
+              };
+            }
+            if (error.message.includes("currentOffice")) {
+              return {
+                ...error,
+                message: "You must select your current office",
+              };
+            }
+            if (error.message.includes("destinationOffice")) {
+              return {
+                ...error,
+                message: "You must select your destination office",
               };
             }
             return error;


### PR DESCRIPTION
- show validation error if user submits the same current office and destination office
- change the 'content' field to 'reason' field