### PR TITLE
fix: change success notification after creating request successfully

### DIFF
--- a/src/intl.ts
+++ b/src/intl.ts
@@ -110,6 +110,10 @@ export const commonMessages = defineMessages({
     id: "TKmub+",
     defaultMessage: "This field is required",
   },
+  createSuccess: {
+    id: "gdQdWv",
+    defaultMessage: "Create request successfully",
+  },
   savedChanges: {
     id: "rqiCWU",
     defaultMessage: "Saved changes",

--- a/src/taskboard/components/FormCreateTask/FormCreateTask.tsx
+++ b/src/taskboard/components/FormCreateTask/FormCreateTask.tsx
@@ -37,7 +37,7 @@ const FormCreateTask: React.FC<Props> = ({ onClose, id }) => {
     onCompleted: () => {
       notify({
         status: "success",
-        text: intl.formatMessage(commonMessages.savedChanges),
+        text: intl.formatMessage(commonMessages.createSuccess),
       });
       onClose();
     },


### PR DESCRIPTION
- change success notification after creating request successfully from "Saved changes" to "Create request successfully"